### PR TITLE
[Feature] Add support for legacy NeoForge

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModdevgradleExtension.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModdevgradleExtension.kt
@@ -142,13 +142,14 @@ class RegularEnableConfiguration(impl: BaseModdevgradleImpl, private val extensi
     }
 }
 class LegacyEnableConfiguration(impl: BaseModdevgradleImpl, private val extension: LegacyForgeExtension) : MDGEnableConfigurationInternal(impl) {
-    override var neoForgeVersion: String? by NotExistsNullableDelegate()
+    override var neoForgeVersion: String? = null
     override var neoFormVersion: String? by NotExistsNullableDelegate()
     override var forgeVersion: String? = null
     override var mcpVersion: String? = null
 
     override fun enable(target: Project) {
         extension.enable {
+            neoForgeVersion = this@LegacyEnableConfiguration.neoForgeVersion
             forgeVersion = this@LegacyEnableConfiguration.forgeVersion
             mcpVersion = this@LegacyEnableConfiguration.mcpVersion
         }


### PR DESCRIPTION
Despite the name, `moddev.legacyforge` also handles legacy versions of NeoForge. However, Modstitch doesn't support specifying `neoForgeVersion` when the target platform is MDG Legacy. This PR fixes it. Other parts of the code seem to already handle this scenario just fine.