### PR TITLE
Gradle property conventions

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/extensions/Metadata.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/extensions/Metadata.kt
@@ -1,8 +1,10 @@
 package dev.isxander.modstitch.base.extensions
 
+import dev.isxander.modstitch.util.propConvention
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
@@ -68,15 +70,34 @@ interface MetadataBlock {
      */
     val replacementProperties: MapProperty<String, String>
 }
-open class MetadataBlockImpl @Inject constructor(objects: ObjectFactory) : MetadataBlock {
+open class MetadataBlockImpl @Inject constructor(providers: ProviderFactory, objects: ObjectFactory) : MetadataBlock {
     /** Mods should use a `lower_snake_case` mod-id to obey the conventions of both mod loaders. */
-    override val modId = objects.property<String>().convention("unnamed_mod")
-    override val modName = objects.property<String>().convention("Unnamed Mod")
-    override val modVersion = objects.property<String>().convention("1.0.0")
-    override val modDescription = objects.property<String>().convention("")
-    override val modLicense = objects.property<String>().convention("All Rights Reserved")
-    override val modGroup = objects.property<String>().convention("com.example")
-    override val modAuthor = objects.property<String>().convention("")
-    override val modCredits = objects.property<String>().convention("")
-    override val replacementProperties = objects.mapProperty<String, String>().convention(emptyMap())
+    override val modId = objects.property<String>()
+        .propConvention(providers.prop("modId"))
+        .convention("unnamed_mod")
+    override val modName = objects.property<String>()
+        .propConvention(providers.prop("modName"))
+        .convention("Unnamed Mod")
+    override val modVersion = objects.property<String>()
+        .propConvention(providers.prop("modVersion"))
+        .convention("1.0.0")
+    override val modDescription = objects.property<String>()
+        .propConvention(providers.prop("modDescription"))
+        .convention("")
+    override val modLicense = objects.property<String>()
+        .propConvention(providers.prop("modLicense"))
+        .convention("All Rights Reserved")
+    override val modGroup = objects.property<String>()
+        .propConvention(providers.prop("modGroup"))
+        .convention("com.example")
+    override val modAuthor = objects.property<String>()
+        .propConvention(providers.prop("modAuthor"))
+        .convention("")
+    override val modCredits = objects.property<String>()
+        .propConvention(providers.prop("modCredits"))
+        .convention("")
+    override val replacementProperties = objects.mapProperty<String, String>()
+        .convention(emptyMap())
+
+    private fun ProviderFactory.prop(suffix: String) = gradleProperty("modstitch.metadata.${suffix}")
 }

--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomExtension.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomExtension.kt
@@ -8,11 +8,13 @@ import dev.isxander.modstitch.PlatformExtension
 import dev.isxander.modstitch.base.extensions.modstitch
 import dev.isxander.modstitch.util.ExtensionGetter
 import dev.isxander.modstitch.util.NotExistsDelegate
+import dev.isxander.modstitch.util.propConvention
 import net.fabricmc.loom.api.LoomGradleExtensionAPI
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.kotlin.dsl.*
 import javax.inject.Inject
 
@@ -35,10 +37,12 @@ interface BaseLoomExtension : PlatformExtension<BaseLoomExtension> {
 }
 
 open class BaseLoomExtensionImpl @Inject constructor(
+    providers: ProviderFactory,
     objects: ObjectFactory,
     @Transient private val project: Project
 ) : BaseLoomExtension {
     override val fabricLoaderVersion: Property<String> = objects.property<String>()
+        .propConvention(providers.prop("fabricLoaderVersion"))
 
     override val loomExtension: LoomGradleExtensionAPI by ExtensionGetter(project)
     override fun configureLoom(action: Action<LoomGradleExtensionAPI>) =
@@ -46,6 +50,8 @@ open class BaseLoomExtensionImpl @Inject constructor(
 
     override fun applyIfCurrent(configure: Action<BaseLoomExtension>) =
         configure.execute(this)
+
+    private fun ProviderFactory.prop(suffix: String) = gradleProperty("modstitch.loom.${suffix}")
 }
 
 open class BaseLoomExtensionDummy : BaseLoomExtension {

--- a/src/main/kotlin/dev/isxander/modstitch/util/ProviderUtils.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/ProviderUtils.kt
@@ -1,6 +1,27 @@
 package dev.isxander.modstitch.util
 
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+
+/**
+ * If the Gradle property “something” is defined, apply the converted value
+ * as the convention (default) for this `Property<T>`.
+ * If the property is absent, nothing happens – the `Property` stays unset.
+ */
+fun <T : Any> Property<T>.propConvention(
+    propertyProvider: Provider<String>,           // e.g. providers.gradleProperty("something")
+    converter: (String) -> T                      // non-null converter
+): Property<T> = apply {
+    // `map` is lazy: converter runs only when the provider is present.
+    convention(propertyProvider.map(converter))
+}
+/**
+ * If the Gradle property “something” is defined, use it
+ * as the convention (default) for this `Property<String>`.
+ * If the property is absent, nothing happens – the `Property` stays unset.
+ */
+fun Property<String>.propConvention(propertyProvider: Provider<String>): Property<String> =
+    propConvention(propertyProvider) { it }
 
 fun <I1, I2, R> zip(i1: Provider<I1>, i2: Provider<I2>, f: (I1, I2) -> R): Provider<R> {
     return i1.zip(i2, f)


### PR DESCRIPTION
This PR introduces conventions for all configurable extension properties, mapping their default value to an equivalently named gradle property.

In its current state, it's missing configuration for MDG side of things, since it doesn't use gradle properties, and I'm not sure how best to tackle it.

Closes #13 