### PR TITLE
Use Fabric Loader 0.15.0 by default

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomExtension.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomExtension.kt
@@ -19,6 +19,8 @@ import javax.inject.Inject
 interface BaseLoomExtension : PlatformExtension<BaseLoomExtension> {
     /**
      * The version of Fabric Loader to use.
+     *
+     * Defaults to `0.15.0`.
      */
     val fabricLoaderVersion: Property<String>
 
@@ -38,7 +40,7 @@ open class BaseLoomExtensionImpl @Inject constructor(
     objects: ObjectFactory,
     @Transient private val project: Project
 ) : BaseLoomExtension {
-    override val fabricLoaderVersion: Property<String> = objects.property<String>()
+    override val fabricLoaderVersion: Property<String> = objects.property<String>().convention("0.15.0")
 
     override val loomExtension: LoomGradleExtensionAPI by ExtensionGetter(project)
     override fun configureLoom(action: Action<LoomGradleExtensionAPI>) =


### PR DESCRIPTION
This is a small one. So, unlike (Neo)Forge, Fabric is quite generic and doesn't require a separate version for every single Minecraft release. Thus, we can provide a good default value for it right out of the box. Here's my reasoning for why 0.15.0 is the ideal candidate for this role, and why I personally always target it during development:
- It's been around long enough for most users to have updated to it, or to an even newer version
- It's the last version that introduced a major change: starting with 0.15.0, Fabric Loader ships with `MixinExtras`, so mod developers no longer need to JiJ it in their mods
- As of this writing, it works flawlessly with all Minecraft versions starting from 1.14.x up to the latest 1.21.7
- Given all the above, targeting this version ensures compatibility with most setups currently used by players, while still providing nice QoL features like `MixinExtras`
- Even if 0.15.0 becomes outdated one day, selecting a new default will be pretty easy, since newer versions of Fabric Loader only expand their range of supported Minecraft versions
- And finally, it's a nice round number :3