### PR TITLE
Implement sensible defaults for `javaVersion`

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
@@ -145,7 +145,7 @@ abstract class BaseCommonImpl<T : Any>(
 
         target.extensions.configure<JavaPluginExtension> {
             target.afterEvaluate {
-                val javaVersion = JavaVersion.toVersion(target.modstitch.javaTarget.get())
+                val javaVersion = JavaVersion.toVersion(target.modstitch.javaVersion.get())
                 targetCompatibility = javaVersion
                 sourceCompatibility = javaVersion
             }

--- a/src/main/kotlin/dev/isxander/modstitch/base/extensions/Modstitch.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/extensions/Modstitch.kt
@@ -106,7 +106,7 @@ interface ModstitchExtension {
     /**
      * The Java version to target.
      */
-    val javaTarget: Property<Int>
+    val javaVersion: Property<Int>
 
     /**
      * The Parchment configuration block.
@@ -286,7 +286,8 @@ open class ModstitchExtensionImpl @Inject constructor(
         set(value) = if (value != null) platformExtension<BaseModDevGradleExtension> { enable { mcpVersion = value } } else {}
 
     override val minecraftVersion = objects.property<String>()
-    override val javaTarget = objects.property<Int>()
+
+    override val javaVersion = objects.property<Int>()
 
     override val parchment = objects.newInstance<ParchmentBlockImpl>(objects)
     init { parchment.minecraftVersion.convention(minecraftVersion) }

--- a/src/main/kotlin/dev/isxander/modstitch/base/extensions/Modstitch.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/extensions/Modstitch.kt
@@ -105,6 +105,12 @@ interface ModstitchExtension {
 
     /**
      * The Java version to target.
+     *
+     * - Defaults to `21` if [minecraftVersion] >= `1.20.5`.
+     * - Defaults to `17` if [minecraftVersion] >= `1.18`.
+     * - Defaults to `16` if [minecraftVersion] >= `1.17`.
+     * - Defaults to  `8` if [minecraftVersion] <= `1.16.5`.
+     * - Has no default value if [minecraftVersion] denotes a snapshot version.
      */
     val javaVersion: Property<Int>
 
@@ -287,7 +293,15 @@ open class ModstitchExtensionImpl @Inject constructor(
 
     override val minecraftVersion = objects.property<String>()
 
-    override val javaVersion = objects.property<Int>()
+    override val javaVersion = objects.property<Int>().convention(minecraftVersion.map { v ->
+        // https://minecraft.wiki/w/Tutorial:Update_Java
+        ReleaseVersion.parseOrNull(v)?.let { when {
+            it >= ReleaseVersion(1, 20, 5) -> 21
+            it >= ReleaseVersion(1, 18, 0) -> 17
+            it >= ReleaseVersion(1, 17, 0) -> 16
+            else -> 8
+        }}
+    })
 
     override val parchment = objects.newInstance<ParchmentBlockImpl>(objects)
     init { parchment.minecraftVersion.convention(minecraftVersion) }

--- a/src/main/kotlin/dev/isxander/modstitch/util/ReleaseVersion.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/ReleaseVersion.kt
@@ -26,13 +26,13 @@ internal data class ReleaseVersion(val major: Int, val minor: Int, val patch: In
         /**
          * A pattern used to match release version strings.
          */
-        private val PATTERN = Regex("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?")
+        private val PATTERN = Regex("^\\s*(\\d+)\\.(\\d+)(?:\\.(\\d+))?")
 
         /**
          * Attempts to parse a dot-separated version string into a [ReleaseVersion].
          *
-         * Accepts up to three numeric components (e.g., "1", "1.2", "1.2.3").
-         * Missing components default to zero.
+         * Accepts two or three numeric components (e.g., "1.2" or "1.2.3").
+         * Missing patch component defaults to zero.
          *
          * @param value The input string to parse.
          * @return A [ReleaseVersion] instance, or `null` if parsing fails.

--- a/src/main/kotlin/dev/isxander/modstitch/util/ReleaseVersion.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/ReleaseVersion.kt
@@ -24,6 +24,11 @@ internal data class ReleaseVersion(val major: Int, val minor: Int, val patch: In
 
     companion object {
         /**
+         * A pattern used to match release version strings.
+         */
+        private val PATTERN = Regex("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?")
+
+        /**
          * Attempts to parse a dot-separated version string into a [ReleaseVersion].
          *
          * Accepts up to three numeric components (e.g., "1", "1.2", "1.2.3").
@@ -32,12 +37,7 @@ internal data class ReleaseVersion(val major: Int, val minor: Int, val patch: In
          * @param value The input string to parse.
          * @return A [ReleaseVersion] instance, or `null` if parsing fails.
          */
-        fun parseOrNull(value: CharSequence): ReleaseVersion? {
-            val parts = value.splitToSequence('.').take(3).map { it.toIntOrNull() }.toList()
-            if (parts.isEmpty() || parts.any { it == null }) {
-                return null
-            }
-            return ReleaseVersion(parts[0] ?: 0, parts.elementAtOrNull(1) ?: 0, parts.elementAtOrNull(2) ?: 0)
-        }
+        fun parseOrNull(value: CharSequence): ReleaseVersion? =
+            PATTERN.find(value)?.groupValues?.map { it.toIntOrNull() ?: 0 }?.let { ReleaseVersion(it[1], it[2], it[3]) }
     }
 }

--- a/src/main/kotlin/dev/isxander/modstitch/util/ReleaseVersion.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/ReleaseVersion.kt
@@ -1,0 +1,43 @@
+package dev.isxander.modstitch.util
+
+/**
+ * Represents a semantic version without pre-release or build metadata components.
+ *
+ * @property major The major version component.
+ * @property minor The minor version component.
+ * @property patch The patch version component.
+ */
+internal data class ReleaseVersion(val major: Int, val minor: Int, val patch: Int) : Comparable<ReleaseVersion> {
+    /**
+     * Compares this version to another [ReleaseVersion].
+     *
+     * @param other The version to compare against.
+     * @return A negative integer if this version is lower than [other], zero if equal, or a positive integer if greater.
+     */
+    override fun compareTo(other: ReleaseVersion): Int =
+        compareValuesBy(this, other, ReleaseVersion::major, ReleaseVersion::minor, ReleaseVersion::patch)
+
+    /**
+     * Returns a string representation of this version in the `major.minor.patch` format.
+     */
+    override fun toString(): String = "$major.$minor.$patch"
+
+    companion object {
+        /**
+         * Attempts to parse a dot-separated version string into a [ReleaseVersion].
+         *
+         * Accepts up to three numeric components (e.g., "1", "1.2", "1.2.3").
+         * Missing components default to zero.
+         *
+         * @param value The input string to parse.
+         * @return A [ReleaseVersion] instance, or `null` if parsing fails.
+         */
+        fun parseOrNull(value: CharSequence): ReleaseVersion? {
+            val parts = value.splitToSequence('.').take(3).map { it.toIntOrNull() }.toList()
+            if (parts.isEmpty() || parts.any { it == null }) {
+                return null
+            }
+            return ReleaseVersion(parts[0] ?: 0, parts.elementAtOrNull(1) ?: 0, parts.elementAtOrNull(2) ?: 0)
+        }
+    }
+}

--- a/test-project/build.gradle.kts
+++ b/test-project/build.gradle.kts
@@ -5,8 +5,9 @@ modstitch {
     mcpVersion = findProperty("mcpVersion") as String?
     neoFormVersion = findProperty("neoFormVersion") as String?
     minecraftVersion = findProperty("minecraftVersion") as String?
-    javaTarget = 17
+
     println(modLoaderManifest)
+    println(javaVersion.map { "Java version: $it" }.getOrElse("'javaVersion' is not set."))
 
     metadata {
         modId = "test_project"


### PR DESCRIPTION
### Description

`javaVersion` *(previously known as `javaTarget`, which I renamed for consistency purposes, as we use the "Version" suffix throughout the entire codebase, but not here for some reason)* now defaults to the Java version used by the target Minecraft version.