### PR TITLE
fix: respect addMixinsToModManifest property

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
@@ -89,7 +89,11 @@ abstract class BaseCommonImpl<T : Any>(
             dependsOn("processResources")
 
             source(target.mainSourceSet!!.output.resourcesDir!!.resolve(msExt.modLoaderManifest))
-            mixins.value(target.provider { msExt.mixin.configs.map { it.resolved() } })
+            if (msExt.mixin.addMixinsToModManifest.get()) {
+                mixins.value(target.provider { msExt.mixin.configs.map { it.resolved() } })
+            } else {
+                mixins.unset()
+            }
             accessWideners.value(msExt.accessWidenerName.zip(msExt.accessWidener) { n, _ -> listOf(n) }.orElse(listOf()))
         }.also { target.tasks["processResources"].finalizedBy(it) }
     }

--- a/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/AppendNeoForgeMetadataTask.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/AppendNeoForgeMetadataTask.kt
@@ -13,7 +13,9 @@ import java.io.File
 abstract class AppendNeoForgeMetadataTask : AppendModMetadataTask() {
     override fun appendModMetadata(file: File) {
         val config = TomlFormat.instance().createParser().parse(file, FileNotFoundAction.THROW_ERROR)
-        appendNewEntries(config, "mixins", "config", mixins.get().map { it.config })
+        if (mixins.isPresent) {
+            appendNewEntries(config, "mixins", "config", mixins.get().map { it.config })
+        }
         appendNewEntries(config, "accessTransformers", "file", accessWideners.get())
 
         TomlFormat.instance().createWriter().write(config, file, WritingMode.REPLACE)


### PR DESCRIPTION
On current master, mixins would be appended to mod manifests regardless of the addMixinsToModManifest property. This PR fixes that. Note: I have zero experience in developing Gradle plugins, feedback welcome