### PR TITLE
fix: use relativePath instead of file name when excluding mod manifests

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
@@ -208,7 +208,7 @@ abstract class BaseCommonImpl<T : Any>(
                 // Now build the set of manifests to exclude dynamically
                 val manifestsToExclude = Platform.allModManifests - currentManifest
                 // Return true if the file should be excluded, false otherwise
-                fileTreeElement.name in manifestsToExclude
+                fileTreeElement.relativePath.toString() in manifestsToExclude
             }
         }
         // Include the output of "generateModMetadata" as an input directory for the build

--- a/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
@@ -208,7 +208,7 @@ abstract class BaseCommonImpl<T : Any>(
                 // Now build the set of manifests to exclude dynamically
                 val manifestsToExclude = Platform.allModManifests - currentManifest
                 // Return true if the file should be excluded, false otherwise
-                fileTreeElement.relativePath.toString() in manifestsToExclude
+                fileTreeElement.relativePath.pathString in manifestsToExclude
             }
         }
         // Include the output of "generateModMetadata" as an input directory for the build


### PR DESCRIPTION
`fileTreeElement.name` returns file or directory names like `templates`, `META-INF`, `mods.toml`, but `Platform.modManifest` for MDG has relative paths (`META-INF/mods.toml`), so the check would always fail.

This PR updates the PR to use `fileTreeElement.relativePath.pathString` and allows the check to succeed:
<img width="762" height="320" alt="image" src="https://github.com/user-attachments/assets/0c5f2544-dd20-4e54-8ffc-54f22447c1da" />
