### PR TITLE
Apply values from `gradle.properties`

### DIFF
--- a/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/BaseCommonImpl.kt
@@ -4,6 +4,9 @@ import dev.isxander.modstitch.*
 import dev.isxander.modstitch.base.extensions.*
 import dev.isxander.modstitch.util.Platform
 import dev.isxander.modstitch.util.afterSuccessfulEvaluate
+import dev.isxander.modstitch.util.assignIfNotNull
+import dev.isxander.modstitch.util.deepGradleProperty
+import dev.isxander.modstitch.util.gradleProperty
 import dev.isxander.modstitch.util.mainSourceSet
 import dev.isxander.modstitch.util.platform
 import dev.isxander.modstitch.util.printVersion
@@ -36,9 +39,6 @@ abstract class BaseCommonImpl<T : Any>(
         // Set the property for use elsewhere
         target.platform = platform
 
-        // Apply the necessary plugins
-        applyPlugins(target)
-
         // Create our plugin extension
         val msExt = target.extensions.create(
             ModstitchExtension::class.java,
@@ -46,6 +46,11 @@ abstract class BaseCommonImpl<T : Any>(
             ModstitchExtensionImpl::class.java,
             this
         )
+
+        applyGradleProperties(target)
+
+        // Apply the necessary plugins
+        applyPlugins(target)
 
         // Ensure the archivesBaseName is our mod-id
         target.pluginManager.withPlugin("base") {
@@ -152,6 +157,35 @@ abstract class BaseCommonImpl<T : Any>(
                 sourceCompatibility = javaVersion
             }
         }
+    }
+
+    /**
+     * Applies from gradle.properties to a bunch of extension defaults.
+     * Executed before the user can touch the extensions so they can safely change all of this.
+     */
+    protected open fun applyGradleProperties(target: Project) {
+        val modstitch = target.modstitch
+        modstitch.modLoaderVersion assignIfNotNull target.deepGradleProperty("modstitch.modLoaderVersion")
+        modstitch.minecraftVersion assignIfNotNull target.deepGradleProperty("modstitch.minecraftVersion")
+        modstitch.javaVersion assignIfNotNull target.deepGradleProperty("modstitch.javaVersion")?.toIntOrNull()
+        modstitch.parchment.minecraftVersion assignIfNotNull target.deepGradleProperty("modstitch.parchment.minecraftVersion")
+        modstitch.parchment.mappingsVersion assignIfNotNull target.deepGradleProperty("modstitch.parchment.mappingsVersion")
+        modstitch.parchment.parchmentArtifact assignIfNotNull target.deepGradleProperty("modstitch.parchment.parchmentArtifact")
+        modstitch.parchment.enabled assignIfNotNull target.deepGradleProperty("modstitch.parchment.enabled")?.toBooleanStrictOrNull()
+        modstitch.metadata.modId assignIfNotNull target.deepGradleProperty("modstitch.metadata.modId")
+        modstitch.metadata.modName assignIfNotNull target.deepGradleProperty("modstitch.metadata.modName")
+        modstitch.metadata.modVersion assignIfNotNull target.deepGradleProperty("modstitch.metadata.modVersion")
+        modstitch.metadata.modDescription assignIfNotNull target.deepGradleProperty("modstitch.metadata.modDescription")
+        modstitch.metadata.modLicense assignIfNotNull target.deepGradleProperty("modstitch.metadata.modLicense")
+        modstitch.metadata.modGroup assignIfNotNull target.deepGradleProperty("modstitch.metadata.modGroup")
+        modstitch.metadata.modAuthor assignIfNotNull target.deepGradleProperty("modstitch.metadata.modAuthor")
+        modstitch.metadata.modCredits assignIfNotNull target.deepGradleProperty("modstitch.metadata.modCredits")
+        modstitch.metadata.overwriteProjectVersionAndGroup assignIfNotNull target.deepGradleProperty("modstitch.metadata.overwriteProjectVersionAndGroup")?.toBooleanStrictOrNull()
+        modstitch.mixin.addMixinsToModManifest assignIfNotNull target.deepGradleProperty("modstitch.mixin.addMixinsToModManifest")?.toBooleanStrictOrNull()
+        modstitch.accessWidener assignIfNotNull target.deepGradleProperty("modstitch.accessWidener") { v, p -> p.file(v) }
+        modstitch.accessWidenerName assignIfNotNull target.deepGradleProperty("modstitch.accessWidenerName")
+        modstitch.validateAccessWidener assignIfNotNull target.deepGradleProperty("modstitch.validateAccessWidener")?.toBooleanStrictOrNull()
+        modstitch.modLoaderManifest assignIfNotNull target.deepGradleProperty("modstitch.modLoaderManifest")
     }
 
     /**

--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
@@ -26,9 +26,9 @@ class BaseLoomImpl : BaseCommonImpl<BaseLoomExtension>(
     )
 
     override fun apply(target: Project) {
-        super.apply(target)
-
         val fabricExt = createRealPlatformExtension(target)!!
+
+        super.apply(target)
 
         target.dependencies {
             "minecraft"(target.modstitch.minecraftVersion.map { "com.mojang:minecraft:$it" })
@@ -121,6 +121,13 @@ class BaseLoomImpl : BaseCommonImpl<BaseLoomExtension>(
     override fun applyDefaultRepositories(repositories: RepositoryHandler) {
         super.applyDefaultRepositories(repositories)
         repositories.maven("https://maven.fabricmc.net") { name = "FabricMC" }
+    }
+
+    override fun applyGradleProperties(target: Project) {
+        super.applyGradleProperties(target)
+        target.modstitch.loom {
+            fabricLoaderVersion assignIfNotNull target.deepGradleProperty("modstitch.loom.fabricLoaderVersion")
+        }
     }
 
     override fun applyMetadataStringReplacements(target: Project): TaskProvider<ProcessResources> {

--- a/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModDevGradleImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModDevGradleImpl.kt
@@ -7,6 +7,8 @@ import dev.isxander.modstitch.util.Platform
 import dev.isxander.modstitch.util.PlatformExtensionInfo
 import dev.isxander.modstitch.util.addCamelCasePrefix
 import dev.isxander.modstitch.util.afterSuccessfulEvaluate
+import dev.isxander.modstitch.util.assignIfNotNull
+import dev.isxander.modstitch.util.deepGradleProperty
 import dev.isxander.modstitch.util.mainSourceSet
 import net.neoforged.moddevgradle.dsl.ModDevExtension
 import net.neoforged.moddevgradle.dsl.NeoForgeExtension
@@ -44,6 +46,7 @@ class BaseModDevGradleImpl(
 
     override fun apply(target: Project) {
         val ext = createRealPlatformExtension(target, type)!!
+
         super.apply(target)
 
         val modstitch = target.modstitch
@@ -182,6 +185,16 @@ class BaseModDevGradleImpl(
             MDGType.Regular -> "net.neoforged.moddev"
             MDGType.Legacy -> "net.neoforged.moddev.legacyforge"
         })
+    }
+
+    override fun applyGradleProperties(target: Project) {
+        super.applyGradleProperties(target)
+        target.modstitch.moddevgradle {
+            neoForgeVersion assignIfNotNull target.deepGradleProperty("modstitch.moddevgradle.neoForgeVersion")
+            forgeVersion assignIfNotNull target.deepGradleProperty("modstitch.moddevgradle.forgeVersion")
+            neoFormVersion assignIfNotNull target.deepGradleProperty("modstitch.moddevgradle.neoFormVersion")
+            mcpVersion assignIfNotNull target.deepGradleProperty("modstitch.moddevgradle.mcpVersion")
+        }
     }
 
     override fun applyMetadataStringReplacements(target: Project): TaskProvider<ProcessResources> {

--- a/test-project/build.gradle.kts
+++ b/test-project/build.gradle.kts
@@ -1,29 +1,6 @@
 modstitch {
-    minecraftVersion = findProperty("minecraftVersion") as String?
-    javaVersion = 17
-
-    loom {
-        fabricLoaderVersion = findProperty("fabricLoaderVersion") as String?
-    }
-
-    moddevgradle {
-        neoForgeVersion = findProperty("neoForgeVersion") as String?
-        forgeVersion = findProperty("forgeVersion") as String?
-        mcpVersion = findProperty("mcpVersion") as String?
-        neoFormVersion = findProperty("neoFormVersion") as String?
-    }
-
     println(modLoaderManifest.getOrElse("'modLoaderManifest' is not set."))
     println(javaVersion.map { "Java version: $it" }.getOrElse("'javaVersion' is not set."))
-
-    metadata {
-        modId = "test_project"
-        modGroup = "dev.isxander"
-        modVersion = "1.0.0"
-        modLicense = "ARR"
-        modName = "Test Project"
-        modDescription = "A test project for ModStitch"
-    }
 
     moddevgradle {
         defaultRuns()
@@ -31,8 +8,6 @@ modstitch {
 
     mixin {
         configs.create("test")
-
-        addMixinsToModManifest = true
     }
 }
 

--- a/test-project/fabric/gradle.properties
+++ b/test-project/fabric/gradle.properties
@@ -1,4 +1,4 @@
 modstitch.platform=loom
 
-minecraftVersion=1.21.4
-fabricLoaderVersion=0.16.10
+modstitch.minecraftVersion=1.21.4
+modstitch.modLoaderVersion=0.16.10

--- a/test-project/forge/gradle.properties
+++ b/test-project/forge/gradle.properties
@@ -1,4 +1,4 @@
 modstitch.platform=moddevgradle-legacy
 
-minecraftVersion=1.20.1
-forgeVersion=1.20.1-47.3.0
+modstitch.minecraftVersion=1.20.1
+modstitch.modLoaderVersion=1.20.1-47.3.0

--- a/test-project/gradle.properties
+++ b/test-project/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.configuration-cache=true
 
 modstitch.platform=parent
+modstitch.metadata.modId=test_mod
+modstitch.metadata.modName=Test Mod
+modstitch.metadata.modVersion=1.2.3
+modstitch.mixin.addMixinsToModManifest=true

--- a/test-project/neoforge/gradle.properties
+++ b/test-project/neoforge/gradle.properties
@@ -1,4 +1,4 @@
 modstitch.platform=moddevgradle
 
-minecraftVersion=1.20.4
-neoForgeVersion=20.4.239
+modstitch.minecraftVersion=1.20.4
+modstitch.modLoaderVersion=20.4.239


### PR DESCRIPTION
This PR allows you to configure all static modstitch properties from `gradle.properties`.

Closes #13 

The property keys mirror that of the code path.
E.g.,
```kt
modstitch {
  minecraftVersion = "1.21.8"
}
```
could become
```properties
modstitch.minecraftVersion=1.21.8
```

Modstitch searches for values deep within the project tree, meaning it will search through parents' properties too.

## Extra considerations

### Cousin problem

Modstitch is commonly used with tools like Stonecutter. In Stonecutter, the project structure looks like this.

```
:core:1.21.8
:extra:1.21.8
```

This means the `1.21.8` projects are *cousins*, not direct parent/child. This means that when configuring `:extra:1.21.8`, `:core:1.21.8`'s gradle properties are not sourced, which makes sense.

Controlify, my mod, does this exact thing, which would limit the usefulness of this PR, feedback is appreciated.

### Bypass of intellisense

This makes errors a lot more tricky. If Modstitch had an update and changed/removed/renamed a property within its extension, there would be no highlighted error within the properties file, potentially leading to confusion, and tricky errors.