### PR TITLE
Add RetroFuturaGradle support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,6 @@ dependencies {
     implementation(plugin("net.neoforged.moddev", prop = "deps.moddevgradle"))
     implementation(plugin("net.neoforged.moddev.legacyforge", prop = "deps.moddevgradle"))
     implementation(plugin("me.modmuss50.mod-publish-plugin", prop = "deps.mpp"))
-    implementation(plugin("com.gradleup.shadow", prop = "deps.shadow"))
     implementation(plugin("com.gtnewhorizons.retrofuturagradle", prop = "deps.retrofuturagradle"))
     implementation(plugin("xyz.wagyourtail.jvmdowngrader", prop = "deps.jvmDowngrader"))
     // Libraries used within the plugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     idea
 }
 
-group = "dev.isxander.modstitch"
+group = "dev.isxander.modstitchh"
 version = "0.8.4"
 
 repositories {
@@ -62,7 +62,6 @@ dependencies {
     implementation(plugin("net.neoforged.moddev.legacyforge", prop = "deps.moddevgradle"))
     implementation(plugin("me.modmuss50.mod-publish-plugin", prop = "deps.mpp"))
     implementation(plugin("com.gtnewhorizons.retrofuturagradle", prop = "deps.retrofuturagradle"))
-    implementation(plugin("xyz.wagyourtail.jvmdowngrader", prop = "deps.jvmDowngrader"))
     // Libraries used within the plugin
     implementation("com.google.code.gson:gson:2.11.0")
     implementation("com.electronwill.night-config:toml:3.8.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,13 @@ repositories {
     gradlePluginPortal()
     maven("https://maven.fabricmc.net/")
     maven("https://maven.neoforged.net/releases/")
+    maven{
+        url = uri("https://nexus.gtnewhorizons.com/repository/public/")
+        mavenContent {
+            includeGroupByRegex("com\\.gtnewhorizons\\..+")
+            includeGroup("com.gtnewhorizons")
+        }
+    }
 }
 
 fun String.capitalize(): String {
@@ -55,11 +62,13 @@ dependencies {
     implementation(plugin("net.neoforged.moddev.legacyforge", prop = "deps.moddevgradle"))
     implementation(plugin("me.modmuss50.mod-publish-plugin", prop = "deps.mpp"))
     implementation(plugin("com.gradleup.shadow", prop = "deps.shadow"))
-
+    implementation(plugin("com.gtnewhorizons.retrofuturagradle", prop = "deps.retrofuturagradle"))
+    implementation(plugin("xyz.wagyourtail.jvmdowngrader", prop = "deps.jvmDowngrader"))
     // Libraries used within the plugin
     implementation("com.google.code.gson:gson:2.11.0")
     implementation("com.electronwill.night-config:toml:3.8.1")
     implementation("org.semver4j:semver4j:5.5.0")
+    implementation("net.neoforged:srgutils:1.0.11")
 
 
     // Libraries used for testing

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     idea
 }
 
-group = "dev.isxander.modstitchh"
+group = "dev.isxander.modstitch"
 version = "0.8.4"
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,5 @@ org.gradle.jvmargs=-Xmx4G
 deps.loom=1.14.9
 deps.moddevgradle=2.0.137
 deps.mpp=0.8.4
-deps.shadow=8.3.6
 deps.retrofuturagradle=2.0.2
 deps.jvmDowngrader=1.3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,3 @@ deps.loom=1.14.9
 deps.moddevgradle=2.0.137
 deps.mpp=0.8.4
 deps.retrofuturagradle=2.0.2
-deps.jvmDowngrader=1.3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,5 @@ deps.loom=1.14.9
 deps.moddevgradle=2.0.137
 deps.mpp=0.8.4
 deps.shadow=8.3.6
+deps.retrofuturagradle=2.0.2
+deps.jvmDowngrader=1.3.5

--- a/src/main/kotlin/dev/isxander/modstitch/base/BasePlugin.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/BasePlugin.kt
@@ -7,6 +7,7 @@ import dev.isxander.modstitch.base.loom.BaseLoomImpl
 import dev.isxander.modstitch.base.loom.LoomType
 import dev.isxander.modstitch.base.moddevgradle.BaseModDevGradleImpl
 import dev.isxander.modstitch.base.moddevgradle.MDGType
+import dev.isxander.modstitch.base.retrofuturagradle.BaseRetroFuturaGradleImpl
 import dev.isxander.modstitch.util.RegisteredGradlePlugin
 
 @RegisteredGradlePlugin
@@ -17,6 +18,7 @@ class BasePlugin : ModstitchExtensionPlugin("base", platforms) {
             Platform.LoomRemap to BaseLoomImpl(LoomType.Remap),
             Platform.MDG to BaseModDevGradleImpl(MDGType.Regular),
             Platform.MDGLegacy to BaseModDevGradleImpl(MDGType.Legacy),
+            Platform.RFG to BaseRetroFuturaGradleImpl()
         )
     }
 }

--- a/src/main/kotlin/dev/isxander/modstitch/base/extensions/Modstitch.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/extensions/Modstitch.kt
@@ -3,6 +3,7 @@ package dev.isxander.modstitch.base.extensions
 import dev.isxander.modstitch.base.*
 import dev.isxander.modstitch.base.loom.BaseLoomExtension
 import dev.isxander.modstitch.base.moddevgradle.BaseModDevGradleExtension
+import dev.isxander.modstitch.base.retrofuturagradle.BaseRetroFuturaGradleExtension
 import dev.isxander.modstitch.util.*
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
@@ -28,6 +29,10 @@ interface ModstitchExtension {
      * - When target platform is `loom`, this property is equivalent to `loom.fabricLoaderVersion`.
      * - When target platform is `moddevgradle`, this property is equivalent to `moddevgradle.neoForgeVersion`.
      * - When target platform is `moddevgradle-legacy`, this property is equivalent to `moddevgradle.forgeVersion`.
+     * - When target platform is `retrofuturagradle`, this property is equivalent to `retrofuturagradle.forgeVersion`.
+     *
+     *   On retrofuturagradle, the property only serves as a check, because retrofuturagradle forces specific forge
+     *   versions
      */
     val modLoaderVersion: Property<String>
 
@@ -213,6 +218,12 @@ interface ModstitchExtension {
      */
     fun moddevgradle(action: Action<BaseModDevGradleExtension>) {}
 
+    /**
+     * Configures the RetroFuturaGradle extension
+     * The action is only executed if the active platform is RetroFuturaGradle
+     */
+    fun retrofuturagradle(action: Action<BaseRetroFuturaGradleExtension>) {}
+
     val templatesSourceDirectorySet: SourceDirectorySet
 
     /**
@@ -232,6 +243,7 @@ open class ModstitchExtensionImpl @Inject constructor(
         Platform.Loom, Platform.LoomRemap -> project.extensions.getByType<BaseLoomExtension>().fabricLoaderVersion
         Platform.MDG -> project.extensions.getByType<BaseModDevGradleExtension>().neoForgeVersion
         Platform.MDGLegacy -> project.extensions.getByType<BaseModDevGradleExtension>().forgeVersion
+        Platform.RFG -> project.extensions.getByType<BaseRetroFuturaGradleExtension>().forgeVersion
     }
 
     override val minecraftVersion = objects.property<String>()
@@ -301,6 +313,7 @@ open class ModstitchExtensionImpl @Inject constructor(
 
     override fun loom(action: Action<BaseLoomExtension>) = platformExtension(action)
     override fun moddevgradle(action: Action<BaseModDevGradleExtension>) = platformExtension(action)
+    override fun retrofuturagradle(action: Action<BaseRetroFuturaGradleExtension>) = platformExtension(action)
 
     private inline fun <reified T : Any> platformExtension(action: Action<T>) {
         val platformExtension = plugin.platformExtension

--- a/src/main/kotlin/dev/isxander/modstitch/base/extensions/Modstitch.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/extensions/Modstitch.kt
@@ -325,14 +325,12 @@ open class ModstitchExtensionImpl @Inject constructor(
     internal var _finalJarTaskName: String? = null
         set(value) {
             field = value
-            println("Final jar task set to $value")
         }
     override val finalJarTask: TaskProvider<out Jar>
         get() = _finalJarTaskName?.let { project.tasks.named<Jar>(it) } ?: error("Final jar task not set")
     internal var _namedJarTaskName: String? = null
         set(value) {
             field = value
-            println("Named jar task set to $value")
         }
     override val namedJarTask: TaskProvider<out Jar>
         get() = _namedJarTaskName?.let { project.tasks.named<Jar>(it) } ?: error("Named jar task not set")

--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
@@ -264,20 +264,24 @@ class BaseLoomImpl(
 
         val proxyModConfigurationName = configuration.name.addCamelCasePrefix("modstitchMod")
         val proxyRegularConfigurationName = configuration.name.addCamelCasePrefix("modstitch")
-        val proxyDowngradeConfigurationName = configuration.name.addCamelCasePrefix("modstitchDowngrade")
 
-        // does nothing here
-        target.configurations.create(proxyDowngradeConfigurationName) proxy@{
-            configuration.get().extendsFrom(this@proxy)
+
+        val proxyModConf = target.configurations.register(proxyModConfigurationName) proxy@{
+            isCanBeResolved = false
+            isCanBeConsumed = false
+            isCanBeDeclared = true
         }
 
-        target.configurations.create(proxyModConfigurationName) proxy@{
-            target.configurations.named(remapConfigurationName) {
-                extendsFrom(this@proxy)
-            }
+        target.configurations.named(remapConfigurationName) {
+            extendsFrom(proxyModConf.get())
         }
-        target.configurations.create(proxyRegularConfigurationName) proxy@{
+
+        target.configurations.register(proxyRegularConfigurationName) proxy@{
             configuration.get().extendsFrom(this@proxy)
+            isCanBeResolved = false
+            isCanBeConsumed = false
+            isCanBeDeclared = true
+
         }
     }
 

--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
@@ -15,8 +15,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
 import org.gradle.kotlin.dsl.*
-import org.gradle.kotlin.dsl.assign
-import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.accessors.runtime.maybeRegister
 import org.gradle.language.jvm.tasks.ProcessResources
 
 class BaseLoomImpl(
@@ -162,7 +161,8 @@ class BaseLoomImpl(
 
             // loom run configs does not support gradle lazy evaluation
             target.afterSuccessfulEvaluate {
-                target.extensions.getByType<LoomGradleExtensionAPI>().runs.register(modstitch.name) loom@{
+                val loomExt = target.extensions.getByType<LoomGradleExtensionAPI>()
+                maybeRegister(loomExt.runs, modstitch.name) loom@{
                     val loom = this@loom
 
                     modstitch.gameDirectory.orNull?.let { loom.runDir = it.asFile.absolutePath }
@@ -231,13 +231,20 @@ class BaseLoomImpl(
                 target.loom.createRemapConfigurations(sourceSet)
             }
         } else {
-            createProxyConfigurations(target, FutureNamedDomainObjectProvider.from(target.configurations, Constants.Configurations.LOCAL_RUNTIME))
+            createProxyConfigurations(
+                target,
+                FutureNamedDomainObjectProvider.from(target.configurations, Constants.Configurations.LOCAL_RUNTIME)
+            )
         }
 
         super.createProxyConfigurations(target, sourceSet)
     }
 
-    override fun createProxyConfigurations(target: Project, configuration: FutureNamedDomainObjectProvider<Configuration>, defer: Boolean) {
+    override fun createProxyConfigurations(
+        target: Project,
+        configuration: FutureNamedDomainObjectProvider<Configuration>,
+        defer: Boolean,
+    ) {
         if (defer) error("Cannot defer proxy configuration creation in Loom")
 
         // for no-remap, this "remap configuration" is just the regular configuration
@@ -247,6 +254,7 @@ class BaseLoomImpl(
                 .find { it.targetConfigurationName.get() == configuration.name }
                 ?.name
                 ?: error("Loom has not created a remap configuration for ${configuration.name}, modstitch cannot proxy it.")
+
             LoomType.NoRemap -> configuration.name
         }
 

--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
@@ -252,6 +252,12 @@ class BaseLoomImpl(
 
         val proxyModConfigurationName = configuration.name.addCamelCasePrefix("modstitchMod")
         val proxyRegularConfigurationName = configuration.name.addCamelCasePrefix("modstitch")
+        val proxyDowngradeConfigurationName = configuration.name.addCamelCasePrefix("modstitchDowngrade")
+
+        // does nothing here
+        target.configurations.create(proxyDowngradeConfigurationName) proxy@{
+            configuration.get().extendsFrom(this@proxy)
+        }
 
         target.configurations.create(proxyModConfigurationName) proxy@{
             target.configurations.named(remapConfigurationName) {

--- a/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/loom/BaseLoomImpl.kt
@@ -165,7 +165,11 @@ class BaseLoomImpl(
                 maybeRegister(loomExt.runs, modstitch.name) loom@{
                     val loom = this@loom
 
-                    modstitch.gameDirectory.orNull?.let { loom.runDir = it.asFile.absolutePath }
+                    // loom uses a relative path from the project directory
+                    modstitch.gameDirectory.orNull?.let {
+                        loom.runDir = it
+                            .asFile.relativeTo(target.projectDir).path
+                    }
                     modstitch.mainClass.orNull?.let { loom.mainClass = it }
                     modstitch.jvmArgs.orNull?.let { loom.vmArgs.addAll(it) }
                     modstitch.programArgs.orNull?.let { loom.programArgs.addAll(it) }

--- a/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModDevGradleImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModDevGradleImpl.kt
@@ -276,6 +276,7 @@ class BaseModDevGradleImpl(
     override fun createProxyConfigurations(target: Project, configuration: FutureNamedDomainObjectProvider<Configuration>, defer: Boolean) {
         val proxyModConfigurationName = configuration.name.addCamelCasePrefix("modstitchMod")
         val proxyRegularConfigurationName = configuration.name.addCamelCasePrefix("modstitch")
+        val proxyDowngradeConfigurationName = configuration.name.addCamelCasePrefix("modstitchDowngrade")
 
         // already created
         if (target.configurations.find { it.name == proxyModConfigurationName } != null) {
@@ -287,7 +288,7 @@ class BaseModDevGradleImpl(
             return target.afterSuccessfulEvaluate { action(configuration.get()) }
         }
 
-        target.configurations.create(proxyModConfigurationName) proxy@{
+        val regular = target.configurations.create(proxyModConfigurationName) proxy@{
             deferred {
                 it.extendsFrom(this@proxy)
             }
@@ -297,6 +298,14 @@ class BaseModDevGradleImpl(
                     remapConfiguration.extendsFrom(this@proxy)
                 }
             }
+        }
+
+        // does nothing here
+        target.configurations.create(proxyDowngradeConfigurationName) proxy@{
+            deferred {
+                it.extendsFrom(regular)
+            }
+
         }
 
         target.configurations.create(proxyRegularConfigurationName) proxy@{

--- a/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModDevGradleImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/moddevgradle/BaseModDevGradleImpl.kt
@@ -276,7 +276,6 @@ class BaseModDevGradleImpl(
     override fun createProxyConfigurations(target: Project, configuration: FutureNamedDomainObjectProvider<Configuration>, defer: Boolean) {
         val proxyModConfigurationName = configuration.name.addCamelCasePrefix("modstitchMod")
         val proxyRegularConfigurationName = configuration.name.addCamelCasePrefix("modstitch")
-        val proxyDowngradeConfigurationName = configuration.name.addCamelCasePrefix("modstitchDowngrade")
 
         // already created
         if (target.configurations.find { it.name == proxyModConfigurationName } != null) {
@@ -288,10 +287,13 @@ class BaseModDevGradleImpl(
             return target.afterSuccessfulEvaluate { action(configuration.get()) }
         }
 
-        val regular = target.configurations.create(proxyModConfigurationName) proxy@{
+        target.configurations.register(proxyModConfigurationName) proxy@{
             deferred {
                 it.extendsFrom(this@proxy)
             }
+            isCanBeResolved = false
+            isCanBeConsumed = false
+            isCanBeDeclared = true
 
             target.afterSuccessfulEvaluate {
                 if (type == MDGType.Legacy) {
@@ -300,18 +302,13 @@ class BaseModDevGradleImpl(
             }
         }
 
-        // does nothing here
-        target.configurations.create(proxyDowngradeConfigurationName) proxy@{
-            deferred {
-                it.extendsFrom(regular)
-            }
-
-        }
-
-        target.configurations.create(proxyRegularConfigurationName) proxy@{
+        target.configurations.register(proxyRegularConfigurationName) proxy@{
             deferred {
                 it.extendsFrom(this@proxy)
             }
+            isCanBeResolved = false
+            isCanBeConsumed = false
+            isCanBeDeclared = true
 
             target.afterSuccessfulEvaluate {
                 target.configurations.named("additionalRuntimeClasspath") {

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/AppendRFGMetadataTask.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/AppendRFGMetadataTask.kt
@@ -1,0 +1,9 @@
+package dev.isxander.modstitch.base.retrofuturagradle
+
+import dev.isxander.modstitch.base.AppendModMetadataTask
+import java.io.File
+
+abstract class AppendRFGMetadataTask : AppendModMetadataTask() {
+    override fun appendModMetadata(file: File) {
+    }
+}

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleExtension.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleExtension.kt
@@ -1,0 +1,190 @@
+package dev.isxander.modstitch.base.retrofuturagradle
+
+import com.gtnewhorizons.retrofuturagradle.MinecraftExtension
+import dev.isxander.modstitch.base.extensions.ModstitchExtension
+import dev.isxander.modstitch.util.MinecraftVersion
+import dev.isxander.modstitch.util.NotExistsDelegate
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.listProperty
+import org.gradle.kotlin.dsl.property
+import xyz.wagyourtail.jvmdg.gradle.jvmdg
+import xyz.wagyourtail.jvmdg.gradle.task.DowngradeJar
+import xyz.wagyourtail.jvmdg.gradle.task.ShadeJar
+import java.io.File
+import javax.inject.Inject
+
+interface BaseRetroFuturaGradleExtension {
+    /**
+     * The version of Forge to use
+     *
+     * This property is actually only a verification, RetroFuturaGradle only accepts
+     * a single forge version for 1.7.10, and another specific one for 1.12.2
+     */
+    val forgeVersion: Property<String>
+
+
+    /**
+     * The version of MCP to use
+     */
+    val mcpVersion: Property<String>
+
+    /**
+     * The MCP channel to use
+     */
+    val mcpChannel: Property<String>
+
+    /**
+     * Enables the use of JVMDowngrader
+     *
+     * This allows your mod to be compiled on a recent Java version, and downgraded
+     * after being compiled.
+     *
+     * For this to work, you need to shade or provide the API from your development
+     * version at runtime
+     */
+    val enableJvmDowngrader: Property<Boolean>
+
+    /**
+     * Forces the Java version to another one than the mod version requires
+     *
+     * For use with `enableJvmDowngrader`
+     */
+    val developmentJavaVersion: Property<Int>
+
+    // if you use enableJvmDowngrader you must shade this/provide this at runtime
+    /**
+     * If you enable `enableJvmDowngrader` you need to provide these dependencies at runtime
+     * by either shading them in your mod, or by having another mod provide them
+     */
+    val jvmDowngraderApiDependency: Provider<List<File>>
+
+    /**
+     * The JVMDowngrader task that will shade the required API files in the downgraded jar
+     * By default it takes the jar from `jvmDowngraderDowngradeJarTask` as input
+     */
+    val jvmDowngraderShadeApiTask: TaskProvider<ShadeJar>
+
+    /**
+     * The JVMDowngrader task that downgrades your jar to the specified java version in
+     * `modstitch.javaVersion`
+     * By default it uses the jar from the `jar` task
+     */
+    val jvmDowngraderDowngradeJarTask: TaskProvider<DowngradeJar>
+
+    /**
+     * Sets the FMLCorePlugin manifest attribute
+     */
+    val coreModClassName: Property<String>
+
+    /**
+     * Sets the FMLCorePluginContainsFMLMod manifest attribute
+     */
+    val hasModAndCoreMod: Property<Boolean>
+
+
+    /**
+     * The required dependencies for mixins to work
+     *
+     * These will be UniMixins on 1.7.10, and MixinBooter on 1.12.2
+     *
+     * This property is provided to filter them out when shading, since they are mod dependencies
+     * and will have to be provided at runtime
+     */
+    val mixinsDependencies: ListProperty<String>
+
+    /**
+     * The underlying platform-specific extension
+     *
+     * Attempting to access this property on another platform than `retrofuturagradle`
+     * will throw an error
+     */
+    val minecraft: MinecraftExtension
+
+    /**
+     * Configurres the Minecraft extension
+     *
+     * This action will only be executed on the `retrofuturagradle` platform
+     */
+    fun minecraft(action: Action<MinecraftExtension>)
+
+}
+
+open class BaseRetroFuturaGradleExtensionImpl @Inject constructor(
+    objects: ObjectFactory,
+    @Transient private val project: Project,
+) : BaseRetroFuturaGradleExtension {
+    override val forgeVersion: Property<String> = objects.property()
+    override val mcpVersion: Property<String> = objects.property()
+    override val mcpChannel: Property<String> = objects.property()
+    override val enableJvmDowngrader: Property<Boolean> = objects.property<Boolean>()
+    override val jvmDowngraderApiDependency: Provider<List<File>>
+        get() = project.jvmdg.apiJar
+    override val developmentJavaVersion: Property<Int> = objects.property<Int>()
+    override val coreModClassName: Property<String> = objects.property()
+    override val hasModAndCoreMod: Property<Boolean> = objects.property<Boolean>()
+    override val minecraft: MinecraftExtension
+        get() = project.extensions.getByType<MinecraftExtension>()
+    override val jvmDowngraderShadeApiTask: TaskProvider<ShadeJar>
+        get() = project.jvmdg.defaultShadeTask
+    override val mixinsDependencies: ListProperty<String> = objects.listProperty()
+    override val jvmDowngraderDowngradeJarTask: TaskProvider<DowngradeJar>
+        get() = project.jvmdg.defaultTask
+
+    override fun minecraft(action: Action<MinecraftExtension>) = action(minecraft)
+
+    init {
+        forgeVersion.finalizeValueOnRead()
+        mcpVersion.finalizeValueOnRead()
+        mcpChannel.finalizeValueOnRead()
+        enableJvmDowngrader.finalizeValueOnRead()
+        developmentJavaVersion.finalizeValueOnRead()
+        coreModClassName.finalizeValueOnRead()
+        hasModAndCoreMod.finalizeValueOnRead()
+        mixinsDependencies.finalizeValueOnRead()
+        val mixinBooterDeps = listOf(
+            "zone.rong:mixinbooter:10.7",
+            "org.ow2.asm:asm-debug-all:5.2"
+        )
+        val unimixinsMixin = "com.github.LegacyModdingMC.UniMixins:unimixins-all-1.7.10:0.2.1"
+        val mixinDependency = project.provider {
+            project.extensions.getByType<ModstitchExtension>()
+        }.flatMap {
+            it.minecraftVersion
+        }.map {
+            MinecraftVersion.Companion.parseOrderableOrNull(it)?.let {
+                if (it == MinecraftVersion.LegacyRelease(8, 9)) {
+                    mixinBooterDeps
+                } else if (it == MinecraftVersion.LegacyRelease(12, 2)) {
+                    mixinBooterDeps
+                } else if (it == MinecraftVersion.LegacyRelease(7, 10)) {
+                    listOf(unimixinsMixin)
+                } else null
+            }
+        }
+        mixinsDependencies.convention(mixinDependency)
+    }
+}
+
+open class BaseRetroFuturaGradleExtensionDummy : BaseRetroFuturaGradleExtension {
+    override val forgeVersion: Property<String> by NotExistsDelegate()
+    override val mcpVersion: Property<String> by NotExistsDelegate()
+    override val mcpChannel: Property<String> by NotExistsDelegate()
+    override val enableJvmDowngrader: Property<Boolean> by NotExistsDelegate()
+    override val developmentJavaVersion: Property<Int> by NotExistsDelegate()
+    override val coreModClassName: Property<String> by NotExistsDelegate()
+    override val hasModAndCoreMod: Property<Boolean> by NotExistsDelegate()
+    override val jvmDowngraderApiDependency: Provider<List<File>> by NotExistsDelegate()
+    override val minecraft: MinecraftExtension by NotExistsDelegate()
+    override val mixinsDependencies: ListProperty<String> by NotExistsDelegate()
+    override val jvmDowngraderShadeApiTask: TaskProvider<ShadeJar> by NotExistsDelegate()
+    override val jvmDowngraderDowngradeJarTask: TaskProvider<DowngradeJar> by NotExistsDelegate()
+    override fun minecraft(action: Action<MinecraftExtension>) {}
+}

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleExtension.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleExtension.kt
@@ -9,16 +9,10 @@ import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
-import xyz.wagyourtail.jvmdg.gradle.jvmdg
-import xyz.wagyourtail.jvmdg.gradle.task.DowngradeJar
-import xyz.wagyourtail.jvmdg.gradle.task.ShadeJar
-import java.io.File
 import javax.inject.Inject
 
 interface BaseRetroFuturaGradleExtension {
@@ -29,7 +23,6 @@ interface BaseRetroFuturaGradleExtension {
      * a single forge version for 1.7.10, and another specific one for 1.12.2
      */
     val forgeVersion: Property<String>
-
 
     /**
      * The version of MCP to use
@@ -42,44 +35,6 @@ interface BaseRetroFuturaGradleExtension {
     val mcpChannel: Property<String>
 
     /**
-     * Enables the use of JVMDowngrader
-     *
-     * This allows your mod to be compiled on a recent Java version, and downgraded
-     * after being compiled.
-     *
-     * For this to work, you need to shade or provide the API from your development
-     * version at runtime
-     */
-    val enableJvmDowngrader: Property<Boolean>
-
-    /**
-     * Forces the Java version to another one than the mod version requires
-     *
-     * For use with `enableJvmDowngrader`
-     */
-    val developmentJavaVersion: Property<Int>
-
-    // if you use enableJvmDowngrader you must shade this/provide this at runtime
-    /**
-     * If you enable `enableJvmDowngrader` you need to provide these dependencies at runtime
-     * by either shading them in your mod, or by having another mod provide them
-     */
-    val jvmDowngraderApiDependency: Provider<List<File>>
-
-    /**
-     * The JVMDowngrader task that will shade the required API files in the downgraded jar
-     * By default it takes the jar from `jvmDowngraderDowngradeJarTask` as input
-     */
-    val jvmDowngraderShadeApiTask: TaskProvider<ShadeJar>
-
-    /**
-     * The JVMDowngrader task that downgrades your jar to the specified java version in
-     * `modstitch.javaVersion`
-     * By default it uses the jar from the `jar` task
-     */
-    val jvmDowngraderDowngradeJarTask: TaskProvider<DowngradeJar>
-
-    /**
      * Sets the FMLCorePlugin manifest attribute
      */
     val coreModClassName: Property<String>
@@ -88,7 +43,6 @@ interface BaseRetroFuturaGradleExtension {
      * Sets the FMLCorePluginContainsFMLMod manifest attribute
      */
     val hasModAndCoreMod: Property<Boolean>
-
 
     /**
      * The required dependencies for mixins to work
@@ -124,19 +78,11 @@ open class BaseRetroFuturaGradleExtensionImpl @Inject constructor(
     override val forgeVersion: Property<String> = objects.property()
     override val mcpVersion: Property<String> = objects.property()
     override val mcpChannel: Property<String> = objects.property()
-    override val enableJvmDowngrader: Property<Boolean> = objects.property<Boolean>()
-    override val jvmDowngraderApiDependency: Provider<List<File>>
-        get() = project.jvmdg.apiJar
-    override val developmentJavaVersion: Property<Int> = objects.property<Int>()
     override val coreModClassName: Property<String> = objects.property()
     override val hasModAndCoreMod: Property<Boolean> = objects.property<Boolean>()
     override val minecraft: MinecraftExtension
         get() = project.extensions.getByType<MinecraftExtension>()
-    override val jvmDowngraderShadeApiTask: TaskProvider<ShadeJar>
-        get() = project.jvmdg.defaultShadeTask
     override val mixinsDependencies: ListProperty<String> = objects.listProperty()
-    override val jvmDowngraderDowngradeJarTask: TaskProvider<DowngradeJar>
-        get() = project.jvmdg.defaultTask
 
     override fun minecraft(action: Action<MinecraftExtension>) = action(minecraft)
 
@@ -144,8 +90,6 @@ open class BaseRetroFuturaGradleExtensionImpl @Inject constructor(
         forgeVersion.finalizeValueOnRead()
         mcpVersion.finalizeValueOnRead()
         mcpChannel.finalizeValueOnRead()
-        enableJvmDowngrader.finalizeValueOnRead()
-        developmentJavaVersion.finalizeValueOnRead()
         coreModClassName.finalizeValueOnRead()
         hasModAndCoreMod.finalizeValueOnRead()
         mixinsDependencies.finalizeValueOnRead()
@@ -177,14 +121,9 @@ open class BaseRetroFuturaGradleExtensionDummy : BaseRetroFuturaGradleExtension 
     override val forgeVersion: Property<String> by NotExistsDelegate()
     override val mcpVersion: Property<String> by NotExistsDelegate()
     override val mcpChannel: Property<String> by NotExistsDelegate()
-    override val enableJvmDowngrader: Property<Boolean> by NotExistsDelegate()
-    override val developmentJavaVersion: Property<Int> by NotExistsDelegate()
     override val coreModClassName: Property<String> by NotExistsDelegate()
     override val hasModAndCoreMod: Property<Boolean> by NotExistsDelegate()
-    override val jvmDowngraderApiDependency: Provider<List<File>> by NotExistsDelegate()
     override val minecraft: MinecraftExtension by NotExistsDelegate()
     override val mixinsDependencies: ListProperty<String> by NotExistsDelegate()
-    override val jvmDowngraderShadeApiTask: TaskProvider<ShadeJar> by NotExistsDelegate()
-    override val jvmDowngraderDowngradeJarTask: TaskProvider<DowngradeJar> by NotExistsDelegate()
     override fun minecraft(action: Action<MinecraftExtension>) {}
 }

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleExtension.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleExtension.kt
@@ -63,7 +63,7 @@ interface BaseRetroFuturaGradleExtension {
     val minecraft: MinecraftExtension
 
     /**
-     * Configurres the Minecraft extension
+     * Configures the Minecraft extension
      *
      * This action will only be executed on the `retrofuturagradle` platform
      */
@@ -104,9 +104,7 @@ open class BaseRetroFuturaGradleExtensionImpl @Inject constructor(
             it.minecraftVersion
         }.map {
             MinecraftVersion.Companion.parseOrderableOrNull(it)?.let {
-                if (it == MinecraftVersion.LegacyRelease(8, 9)) {
-                    mixinBooterDeps
-                } else if (it == MinecraftVersion.LegacyRelease(12, 2)) {
+                if (it == MinecraftVersion.LegacyRelease(12, 2)) {
                     mixinBooterDeps
                 } else if (it == MinecraftVersion.LegacyRelease(7, 10)) {
                     listOf(unimixinsMixin)

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
@@ -1,0 +1,465 @@
+package dev.isxander.modstitch.base.retrofuturagradle
+
+import com.gtnewhorizons.retrofuturagradle.MinecraftExtension
+import com.gtnewhorizons.retrofuturagradle.UserDevPlugin
+import com.gtnewhorizons.retrofuturagradle.mcp.JSTTransformerTask
+import com.gtnewhorizons.retrofuturagradle.mcp.MCPTasks
+import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar
+import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask
+import com.gtnewhorizons.retrofuturagradle.modutils.ModUtils
+import com.gtnewhorizons.retrofuturagradle.util.Distribution
+import dev.isxander.modstitch.base.BaseCommonImpl
+import dev.isxander.modstitch.base.FutureNamedDomainObjectProvider
+import dev.isxander.modstitch.base.extensions.ModstitchExtension
+import dev.isxander.modstitch.base.extensions.modstitch
+import dev.isxander.modstitch.base.moddevgradle.GenerateAccessTransformerTask
+import dev.isxander.modstitch.util.*
+import net.neoforged.srgutils.IMappingFile
+import org.gradle.api.*
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.FileCollectionDependency
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.internal.tasks.JvmConstants
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
+import org.gradle.jvm.tasks.Jar
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.kotlin.dsl.*
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.gradle.language.jvm.tasks.ProcessResources
+import xyz.wagyourtail.jvmdg.gradle.JVMDowngraderPlugin
+import xyz.wagyourtail.jvmdg.gradle.jvmdg
+
+class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>(
+    Platform.RFG,
+    AppendRFGMetadataTask::class.java
+) {
+
+    val nonDowngradedRegularConfigurations = mutableSetOf<String>()
+
+    override val platformExtensionInfo: PlatformExtensionInfo<BaseRetroFuturaGradleExtension> = PlatformExtensionInfo(
+        "msRetroFuturaGradle",
+        BaseRetroFuturaGradleExtension::class,
+        BaseRetroFuturaGradleExtensionImpl::class,
+        BaseRetroFuturaGradleExtensionDummy::class
+    )
+
+    override fun applyPlugins(target: Project) {
+        super.applyPlugins(target)
+        target.pluginManager.apply(UserDevPlugin::class.java)
+        target.pluginManager.apply(JVMDowngraderPlugin::class.java)
+    }
+
+    override fun applyDefaultRepositories(repositories: RepositoryHandler) {
+        super.applyDefaultRepositories(repositories)
+
+        repositories.maven("https://jitpack.io") {
+            name = "JitPack UniMixins"
+            mavenContent {
+                includeGroup("com.github.LegacyModdingMC.UniMixins")
+            }
+        }
+        repositories.maven("https://maven.cleanroommc.com") {
+            name = "MixinBooter"
+            mavenContent {
+                includeModule("zone.rong", "mixinbooter")
+            }
+        }
+    }
+
+    override fun applyJavaSettings(target: Project) {
+        super.applyJavaSettings(target)
+        val ext = target.extensions.getByType<BaseRetroFuturaGradleExtension>()
+        val modstitch = target.extensions.getByType<ModstitchExtension>()
+        target.extensions.configure<JavaPluginExtension> {
+            target.afterSuccessfulEvaluate {
+                val javaVer = ext.developmentJavaVersion.orNull
+                ext.enableJvmDowngrader.finalizeValueOnRead()
+                if (ext.enableJvmDowngrader.get() && javaVer != null) {
+                    JavaVersion.toVersion(javaVer).let {
+                        sourceCompatibility = it
+                        targetCompatibility = it
+                    }
+                }
+            }
+            toolchain {
+                languageVersion.set(
+                    ext.developmentJavaVersion.orElse(modstitch.javaVersion).map { JavaLanguageVersion.of(it) }
+                )
+                // https://github.com/MinecraftForge/ForgeGradle/issues/597
+                // Important for stable decompilation output or else you get failed
+                // patches with: cannot find hunk target
+                vendor.set(JvmVendorSpec.AZUL)
+            }
+        }
+    }
+
+    override fun apply(target: Project) {
+        val ext = createRealPlatformExtension(target)!!
+        super.apply(target)
+        val modstitch = target.modstitch
+        //todo set final jar tasks modstitch api
+        target.tasks.named("reobfJar", ReobfuscatedJar::class.java) {
+            if (ext.enableJvmDowngrader.get()) {
+                val oldJar = inputJar.get()
+                inputJar.set(target.jvmdg.defaultTask.flatMap { it.archiveFile }.orElse(oldJar))
+            }
+        }
+        target.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
+            if (ext.enableJvmDowngrader.get()) {
+                dependsOn(target.jvmdg.defaultShadeTask)
+            }
+        }
+        modstitch._namedJarTaskName = JvmConstants.JAR_TASK_NAME
+        target.afterSuccessfulEvaluate {
+            if(ext.enableJvmDowngrader.get()) {
+                modstitch._finalJarTaskName = target.jvmdg.defaultShadeTask.name
+            } else {
+                modstitch._finalJarTaskName = "reobfJar"
+            }
+        }
+
+        modstitch.modLoaderManifest.convention(platform.modManifest)
+        val minecraft = target.extensions.getByType<MinecraftExtension>()
+        minecraft.mcVersion.set(modstitch.minecraftVersion)
+        minecraft.mcpMappingChannel.set(ext.mcpChannel)
+        minecraft.mcpMappingVersion.set(ext.mcpVersion)
+        minecraft.extraRunJvmArguments.addAll(
+            mutableListOf(
+                "-ea:${target.group}",
+                "-Dmixin.hotSwap=true",
+                "-Dmixin.check.interfaces=true",
+                "-Dmixin.debug.export=true"
+            )
+        )
+        minecraft.extraRunJvmArguments.addAll(
+            ext.coreModClassName.map {
+                listOf("-Dfml.coreMods.load=$it")
+            }.orElse(emptyList())
+        )
+
+        configureLegacyMixin(target)
+
+        applyRuns(target)
+        fixJvmDowngraderRuns(target)
+    }
+
+    override fun applyClassTweaker(target: Project) {
+        val modstitch = target.extensions.getByType<ModstitchExtension>()
+        val defaultAccessTransformerName = modstitch.metadata.modId.map { "META-INF/${it}_at.cfg" }
+        val generatedAccessTransformer = defaultAccessTransformerName.flatMap {
+            target.layout.buildDirectory
+                .file("modstitch/$it")
+        }.zip(modstitch.classTweaker) { x, _ -> x }
+        val generatedAccessTransformersList = generatedAccessTransformer.map { listOf(it) }.orElse(listOf())
+        val classTweakerName = modstitch.classTweakerName.convention(defaultAccessTransformerName)
+            .map {
+                if (!it.startsWith("META-INF")) {
+                    error("Access transformer name must be placed in META-INF/")
+                } else it
+            }
+        val classTweakerPath = classTweakerName.map { it.split('\\', '/') }
+        modstitch.classTweaker.finalizeValueOnRead()
+        modstitch.classTweakerName.finalizeValueOnRead()
+        modstitch.validateClassTweaker.finalizeValueOnRead()
+
+
+        val mcpTasks = target.extensions.getByType<MCPTasks>()
+
+        val convertMappingsTask = target.tasks.register<ConvertMappingsTask>("convertMappingsForAccessTransformers") {
+            sourceMappingsFile.set(mcpTasks.taskGenerateForgeSrgMappings.flatMap { it.mcpToSrg })
+            targetFormat.set(IMappingFile.Format.TSRG)
+            convertedFile.set(target.layout.buildDirectory.file("generated/convertedMappings.txt"))
+        }
+
+        val generateAccessTransformerTask =
+            target.tasks.register<GenerateAccessTransformerTask>("generateAccessTransformer") {
+                group = "modstitch/internal"
+                description = "Generates an access transformer."
+                classTweaker.set(modstitch.classTweaker)
+                mappings.set(
+                    convertMappingsTask.flatMap { it.convertedFile }
+                )
+                accessTransformer.set(generatedAccessTransformer)
+            }
+
+//        val projectDir = target.projectDir.toPath()
+//        mcpTasks.deobfuscationATs.from(
+//            generateAccessTransformerTask.map {
+//                it.outputs.files.map {
+//                    projectDir.relativize(it.toPath())
+//                }
+//            }
+//        )
+        target.tasks.named<JSTTransformerTask>("applyJST") {
+            this.accessTransformerFiles.setFrom(generateAccessTransformerTask)
+        }
+
+        target.tasks.named<ProcessResources>("processResources") {
+            dependsOn(generateAccessTransformerTask)
+            from(generatedAccessTransformersList) {
+                rename { classTweakerPath.get().last() }
+                into(classTweakerPath.map { it.dropLast(1).joinToString("/") })
+            }
+        }
+        target.tasks.named<Jar>("jar") {
+            manifest {
+                attributes["FMLAT"] = classTweakerPath.get().last()
+            }
+        }
+
+    }
+
+
+    private fun fixJvmDowngraderRuns(target: Project) {
+        val ext = target.extensions.getByType<BaseRetroFuturaGradleExtension>()
+        val defaultShadeTask = target.jvmdg.defaultShadeTask
+        val nonDowngradedJar = target.tasks.named("jar", Jar::class.java).map { it.outputs.files }
+        val downgradedJarOutput = defaultShadeTask.map { it.outputs.files }
+        val nonDowngradedDependencies = target.provider {
+            target.files(
+                nonDowngradedRegularConfigurations
+                    .flatMap {
+                        val config = target.configurations.getByName(it)
+                        if (config.isCanBeResolved) config.resolve() else emptySet()
+                    }
+            )
+        }
+        target.tasks.withType<RunMinecraftTask>().configureEach {
+            if (ext.enableJvmDowngrader.get()) {
+                dependsOn(defaultShadeTask)
+                classpath(downgradedJarOutput.get())
+                val originalClasspath = classpath
+                //downgraded jar in first position
+
+                classpath = downgradedJarOutput.get()
+                    .plus(
+                        originalClasspath
+                            .minus(nonDowngradedJar.get())
+                            .minus(nonDowngradedDependencies.get())
+                    )
+            }
+        }
+    }
+
+
+    private fun applyRuns(target: Project) {
+        val modstitch = target.extensions.getByType<ModstitchExtension>()
+        val ext = target.extensions.getByType<BaseRetroFuturaGradleExtension>()
+
+
+        modstitch.runs.whenObjectAdded {
+            val config = this
+            val taskName = "run${config.name.replaceFirstChar(Char::uppercaseChar)}"
+
+            modstitch.onEnable {
+                config.side.finalizeValueOnRead()
+                target.tasks.maybeRegister<RunMinecraftTask>(
+                    taskName,
+                    config.side.map {
+                        when (it) {
+                            Side.Both -> error("Unknown side for RetroFuturaGradle: $it")
+                            Side.Client -> Distribution.CLIENT
+                            Side.Server -> Distribution.DEDICATED_SERVER
+                        }
+                    }
+                ) {
+                    group = "modstitch/runs"
+                    config.gameDirectory.finalizeValueOnRead()
+                    config.gameDirectory.orNull?.let {
+                        this.workingDir = it.asFile
+                    }
+                    this.mainClass.set(config.mainClass)
+                    this.jvmArguments.set(config.jvmArgs)
+                    this.extraArgs.set(config.programArgs)
+                    config.environmentVariables.finalizeValueOnRead()
+                    config.environmentVariables.orNull?.let { this.environment = it }
+
+                }
+                val bool = target.gradle.startParameter.taskNames[0] == "build"
+                target.tasks.named<Jar>("jar") {
+                    manifest {
+                        val attributeMap = mutableMapOf<String, String>()
+                        val coreModClassName = ext.coreModClassName.orNull
+                        if (coreModClassName != null) {
+                            attributeMap["FMLCorePlugin"] = coreModClassName
+                            if (ext.hasModAndCoreMod.get()) {
+                                attributeMap["FMLCorePluginContainsFMLMod"] = true.toString()
+                                attributeMap["ForceLoadAsMod"] = bool.toString()
+                            }
+                            attributes.putAll(attributeMap)
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+    override fun finalize(target: Project) {
+        val ext = target.extensions.getByType<BaseRetroFuturaGradleExtension>()
+        val minecraft = target.extensions.getByType<MinecraftExtension>()
+        check(minecraft.forgeVersion.get() == ext.forgeVersion.get()) {
+            "Unsupported forge version ${ext.forgeVersion.get()} for RetroFuturaGradle, expected ${minecraft.forgeVersion.get()} " +
+                    "RFG only supports 1 version for 1.7.10 and another one for 1.12.2"
+        }
+        super.finalize(target)
+    }
+
+    override fun applyMetadataStringReplacements(target: Project): TaskProvider<ProcessResources> {
+        val generateModMetadata = super.applyMetadataStringReplacements(target)
+
+        return generateModMetadata
+    }
+
+    override fun applyUnitTesting(target: Project, testFrameworkConfigure: Action<in JUnitPlatformOptions>) {
+        throw UnsupportedOperationException("RetroFuturaGradle does not support unit testing")
+    }
+
+    override fun createProxyConfigurations(
+        target: Project,
+        configuration: FutureNamedDomainObjectProvider<Configuration>,
+        defer: Boolean,
+    ) {
+        val ext = target.extensions.getByType<BaseRetroFuturaGradleExtension>()
+        val modstitch = target.extensions.getByType<ModstitchExtension>()
+        val proxyModConfigurationName = configuration.name.addCamelCasePrefix("modstitchMod")
+        val proxyRegularConfigurationName = configuration.name.addCamelCasePrefix("modstitch")
+        val proxyDowngradeConfigurationName = configuration.name.addCamelCasePrefix("modstitchDowngrade")
+
+        // already created
+        if (target.configurations.find { it.name == proxyModConfigurationName } != null) {
+            return
+        }
+        fun deferred(action: (Configuration) -> Unit) {
+            if (!defer) return action(configuration.get())
+            return target.afterSuccessfulEvaluate { action(configuration.get()) }
+        }
+
+        val proxyMod = target.configurations.create(proxyModConfigurationName) proxy@{
+            deferred {
+                it.extendsFrom(this@proxy)
+            }
+        }
+
+        val rfg = target.dependencies.extensions.getByType<ModUtils.RfgDependencyExtension>()
+        proxyMod.dependencies.configureEach {
+            if (this is FileCollectionDependency) {
+                rfg.deobf(this.files)
+            } else {
+                rfg.deobf(
+                    mapOf(
+                        "group" to this.group.orEmpty(),
+                        "name" to this.name.orEmpty(),
+                        "version" to this.version.orEmpty(),
+                        //todo: RFG also checks the classifier but IDK how to get it from here
+                    )
+                )
+            }
+        }
+
+        deferred {
+            nonDowngradedRegularConfigurations.add(it.name)
+        }
+        nonDowngradedRegularConfigurations.add(proxyRegularConfigurationName)
+        target.configurations.create(proxyRegularConfigurationName) proxy@{
+            deferred {
+                it.extendsFrom(this@proxy)
+            }
+        }
+        val javaVersion = modstitch.javaVersion.map {
+            JavaVersion.toVersion(it)
+        }
+        val downgrade = target.configurations.create(proxyDowngradeConfigurationName) proxy@{
+            deferred {
+                it.extendsFrom(this@proxy)
+            }
+        }
+        target.afterSuccessfulEvaluate {
+            if (ext.enableJvmDowngrader.get()) {
+                target.jvmdg.dg(downgrade, false) {
+                    downgradeTo.set(javaVersion)
+                }
+            }
+        }
+    }
+
+    override fun configureJiJConfiguration(target: Project, configuration: Configuration) {
+        target.afterSuccessfulEvaluate {
+            configuration.dependencies.whenObjectAdded {
+                error("RetroFuturaGradle does not support JarInJar, please use the 'modstitch' configuration instead'")
+            }
+        }
+    }
+
+
+    @Suppress("UnstableApiUsage")
+    private fun configureLegacyMixin(target: Project) {
+        val modstitch = target.extensions.getByType<ModstitchExtension>()
+        val ext = target.extensions.getByType<BaseRetroFuturaGradleExtension>()
+        val stitchedMixin = modstitch.mixin
+        ext.mixinsDependencies.finalizeValueOnRead()
+
+        addMixinDependencies(target, ext.mixinsDependencies)
+        val modUtils = target.extensions.getByType<ModUtils>()
+        modUtils.enableMixins(
+            null,
+            modstitch.metadata.modId.map { "$it.refmap.json" }.get()
+        )
+
+        stitchedMixin.mixinSourceSets.whenObjectAdded obj@{
+            modUtils.mixinSourceSet.set(target.sourceSets[this.sourceSetName.get()])
+        }
+        target.afterEvaluate {
+            if (stitchedMixin.mixinSourceSets.size > 1) {
+                //technically it does but we'll see later
+                error("RetroFuturaGradle does not support multiple mixin source sets")
+            }
+            if (stitchedMixin.configs.size > 1) {
+                error("RetroFuturaGradle does not support multiple mixin configs")
+            }
+        }
+    }
+
+    override fun onEnable(target: Project, action: Action<Project>) {
+        target.afterSuccessfulEvaluate(action)
+    }
+}
+
+
+private fun addMixinDependencies(
+    target: Project,
+    dependencies: Provider<List<String>>,
+) {
+    target.afterSuccessfulEvaluate {
+        target.dependencies {
+            val implementation = target.configurations.named(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME)
+            val annotationProcessor =
+                target.configurations.getByName(JvmConstants.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
+            dependencies.get().forEach {
+                implementation(it)
+                annotationProcessor(it)
+            }
+        }
+    }
+}
+
+
+
+inline fun <reified T : Task> TaskContainer.maybeRegister(
+    name: String,
+    vararg constructorArgs: Any,
+    configure: Action<T>,
+) {
+
+    if (name in names) {
+        this.withType<T>().named(name, configure)
+    } else {
+        this.register(name, T::class.java, configure, constructorArgs)
+    }
+}
+
+

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
@@ -396,7 +396,6 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
     }
 
 
-    @Suppress("UnstableApiUsage")
     private fun configureLegacyMixin(target: Project) {
         val modstitch = target.extensions.getByType<ModstitchExtension>()
         val ext = target.extensions.getByType<BaseRetroFuturaGradleExtension>()
@@ -427,21 +426,20 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
     override fun onEnable(target: Project, action: Action<Project>) {
         target.afterSuccessfulEvaluate(action)
     }
-}
 
-
-private fun addMixinDependencies(
-    target: Project,
-    dependencies: Provider<List<String>>,
-) {
-    target.afterSuccessfulEvaluate {
-        target.dependencies {
-            val implementation = target.configurations.named(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME)
-            val annotationProcessor =
-                target.configurations.getByName(JvmConstants.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
-            dependencies.get().forEach {
-                implementation(it)
-                annotationProcessor(it)
+    private fun addMixinDependencies(
+        target: Project,
+        dependencies: Provider<List<String>>,
+    ) {
+        target.afterSuccessfulEvaluate {
+            target.dependencies {
+                val implementation = target.configurations.named(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME)
+                val annotationProcessor =
+                    target.configurations.getByName(JvmConstants.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
+                dependencies.get().forEach {
+                    implementation(it)
+                    annotationProcessor(it)
+                }
             }
         }
     }
@@ -449,17 +447,6 @@ private fun addMixinDependencies(
 
 
 
-inline fun <reified T : Task> TaskContainer.maybeRegister(
-    name: String,
-    vararg constructorArgs: Any,
-    configure: Action<T>,
-) {
 
-    if (name in names) {
-        this.withType<T>().named(name, configure)
-    } else {
-        this.register(name, T::class.java, configure, constructorArgs)
-    }
-}
 
 

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
@@ -364,9 +364,3 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
         }
     }
 }
-
-
-
-
-
-

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
@@ -90,14 +90,6 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
         minecraft.mcpMappingChannel.set(ext.mcpChannel)
         minecraft.mcpMappingVersion.set(ext.mcpVersion)
         minecraft.extraRunJvmArguments.addAll(
-            mutableListOf(
-                "-ea:${target.group}",
-                "-Dmixin.hotSwap=true",
-                "-Dmixin.check.interfaces=true",
-                "-Dmixin.debug.export=true"
-            )
-        )
-        minecraft.extraRunJvmArguments.addAll(
             ext.coreModClassName.map {
                 listOf("-Dfml.coreMods.load=$it")
             }.orElse(emptyList())
@@ -130,6 +122,7 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
 
         val mcpTasks = target.extensions.getByType<MCPTasks>()
 
+        // Convert's RetroFuturaGradle's SRG mappings into TSRG for the access transformer conversion
         val convertMappingsTask = target.tasks.register<ConvertMappingsTask>("convertMappingsForAccessTransformers") {
             sourceMappingsFile.set(mcpTasks.taskGenerateForgeSrgMappings.flatMap { it.mcpToSrg })
             targetFormat.set(IMappingFile.Format.TSRG)
@@ -147,14 +140,6 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
                 accessTransformer.set(generatedAccessTransformer)
             }
 
-//        val projectDir = target.projectDir.toPath()
-//        mcpTasks.deobfuscationATs.from(
-//            generateAccessTransformerTask.map {
-//                it.outputs.files.map {
-//                    projectDir.relativize(it.toPath())
-//                }
-//            }
-//        )
         target.tasks.named<JSTTransformerTask>("applyJST") {
             this.accessTransformerFiles.setFrom(generateAccessTransformerTask)
         }
@@ -166,6 +151,8 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
                 into(classTweakerPath.map { it.dropLast(1).joinToString("/") })
             }
         }
+
+        // Sets the name of the access transformer files in the jar manifest
         target.tasks.named<Jar>("jar") {
             manifest {
                 attributes["FMLAT"] = classTweakerPath.get().last()
@@ -207,7 +194,7 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
                     this.extraArgs.addAll(config.programArgs)
                     this.environment.putAll(config.environmentVariables.get())
                 }
-                val bool = target.gradle.startParameter.taskNames[0] == "build"
+                val bool = target.gradle.startParameter.taskNames.firstOrNull() == "build"
                 target.tasks.named<Jar>("jar") {
                     manifest {
                         val attributeMap = mutableMapOf<String, String>()
@@ -232,15 +219,9 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
         val minecraft = target.extensions.getByType<MinecraftExtension>()
         check(minecraft.forgeVersion.get() == ext.forgeVersion.get()) {
             "Unsupported forge version ${ext.forgeVersion.get()} for RetroFuturaGradle, expected ${minecraft.forgeVersion.get()} " +
-                    "RFG only supports 1 version for 1.7.10 and another one for 1.12.2"
+                    "RetroFuturaGradle only supports 1 version for 1.7.10 and another one for 1.12.2"
         }
         super.finalize(target)
-    }
-
-    override fun applyMetadataStringReplacements(target: Project): TaskProvider<ProcessResources> {
-        val generateModMetadata = super.applyMetadataStringReplacements(target)
-
-        return generateModMetadata
     }
 
     override fun applyUnitTesting(target: Project, testFrameworkConfigure: Action<in JUnitPlatformOptions>) {

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/BaseRetroFuturaGradleImpl.kt
@@ -306,7 +306,7 @@ class BaseRetroFuturaGradleImpl : BaseCommonImpl<BaseRetroFuturaGradleExtension>
     override fun configureJiJConfiguration(target: Project, configuration: Configuration) {
         target.afterSuccessfulEvaluate {
             configuration.dependencies.whenObjectAdded {
-                error("RetroFuturaGradle does not support JarInJar, please use the 'modstitch' configuration instead'")
+                error("RetroFuturaGradle does not support JarInJar, please use the 'modstitch' configuration instead")
             }
         }
     }

--- a/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/ConvertMappingsTask.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/base/retrofuturagradle/ConvertMappingsTask.kt
@@ -1,0 +1,34 @@
+package dev.isxander.modstitch.base.retrofuturagradle
+
+import net.neoforged.srgutils.IMappingFile
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class ConvertMappingsTask : DefaultTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceMappingsFile: RegularFileProperty
+
+    @get:Input
+    abstract val targetFormat: Property<IMappingFile.Format>
+
+    @get:OutputFile
+    abstract val convertedFile: RegularFileProperty
+
+    @TaskAction
+    fun convert() {
+        val loadedMappings = IMappingFile.load(this.sourceMappingsFile.get().asFile)
+        loadedMappings.write(convertedFile.get().asFile.toPath(), targetFormat.get(), false)
+    }
+
+}

--- a/src/main/kotlin/dev/isxander/modstitch/util/ClassTweaker.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/ClassTweaker.kt
@@ -85,7 +85,7 @@ internal data class ClassTweaker(
                             .append(' ')
                             .append(entry.fieldName)
                             .append(' ')
-                            .appendLine(entry.fieldDescriptor ?: "")
+                        // Forge's AccessTransformers don't use field descriptors
                         is ClassTweakerEntry.AccessModifier.Method -> writer
                             .append(' ')
                             .append(entry.methodName)

--- a/src/main/kotlin/dev/isxander/modstitch/util/ClassTweaker.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/ClassTweaker.kt
@@ -85,6 +85,7 @@ internal data class ClassTweaker(
                             .append(' ')
                             .append(entry.fieldName)
                             .append(' ')
+                            .appendLine()
                         // Forge's AccessTransformers don't use field descriptors
                         is ClassTweakerEntry.AccessModifier.Method -> writer
                             .append(' ')

--- a/src/main/kotlin/dev/isxander/modstitch/util/Platform.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/Platform.kt
@@ -6,7 +6,8 @@ enum class Platform(val friendlyName: String, val modManifest: String) {
     Loom("fabric-loom", "fabric.mod.json"),
     LoomRemap("fabric-loom-remap", "fabric.mod.json"),
     MDG("moddevgradle", "META-INF/neoforge.mods.toml"),
-    MDGLegacy("moddevgradle-legacy", "META-INF/mods.toml");
+    MDGLegacy("moddevgradle-legacy", "META-INF/mods.toml"),
+    RFG("retrofuturagradle","mcmod.info");
 
     val isModDevGradle: Boolean
         get() = this in listOf(MDG, MDGLegacy)

--- a/src/main/kotlin/dev/isxander/modstitch/util/Platform.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/Platform.kt
@@ -7,7 +7,7 @@ enum class Platform(val friendlyName: String, val modManifest: String) {
     LoomRemap("fabric-loom-remap", "fabric.mod.json"),
     MDG("moddevgradle", "META-INF/neoforge.mods.toml"),
     MDGLegacy("moddevgradle-legacy", "META-INF/mods.toml"),
-    RFG("retrofuturagradle","mcmod.info");
+    RFG("retrofuturagradle", "mcmod.info");
 
     val isModDevGradle: Boolean
         get() = this in listOf(MDG, MDGLegacy)

--- a/src/main/kotlin/dev/isxander/modstitch/util/ProjectUtils.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/ProjectUtils.kt
@@ -2,9 +2,12 @@ package dev.isxander.modstitch.util
 
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.kotlin.dsl.withType
 
 /**
  * Gets the [SourceSetContainer] from the project's extensions, if available.
@@ -32,6 +35,26 @@ internal val Project.projectChain: Sequence<Project>
 internal fun Project.afterSuccessfulEvaluate(action: Action<Project>) = project.afterEvaluate {
     if (state.failure == null) {
         action.execute(this)
+    }
+}
+
+/**
+ *  Registers or configures the task with the given name and type
+ *
+ *  @param name The name of the task to configure or register
+ *  @param constructorArgs The constructor arguments of the task
+ *  @param configure The configuration block
+ */
+internal inline fun <reified T : Task> TaskContainer.maybeRegister(
+    name: String,
+    vararg constructorArgs: Any,
+    configure: Action<T>,
+) {
+
+    if (name in names) {
+        this.withType<T>().named(name, configure)
+    } else {
+        this.register(name, T::class.java, configure, constructorArgs)
     }
 }
 

--- a/src/main/kotlin/dev/isxander/modstitch/util/ProjectUtils.kt
+++ b/src/main/kotlin/dev/isxander/modstitch/util/ProjectUtils.kt
@@ -54,7 +54,8 @@ internal inline fun <reified T : Task> TaskContainer.maybeRegister(
     if (name in names) {
         this.withType<T>().named(name, configure)
     } else {
-        this.register(name, T::class.java, configure, constructorArgs)
+        val register = this.register(name, T::class.java, *constructorArgs)
+        register.configure(configure)
     }
 }
 


### PR DESCRIPTION
I have started a mod project over here https://github.com/ArchipelagoMinecraft/CoreClient
that aims to support modern (1.17+) and legacy (1.7.10, 1.12.2) minecraft versions.

Currently with modstitch, you can only use moddevgradle-legacy to go down to 1.17, and in a fork I have implemented support for RetroFuturaGradle (https://github.com/GTNewHorizons/RetroFuturaGradle) used for 1.7.10 and 1.12.2 modding.

I'm doing a PR in case you think it's something that has its place here.

And maybe the JVM Downgrader support I put in specifically in RFG could be added in a platform-agnostic way

This PR also adds SRGUtils to convert the SRG mappings RFG generates into TSRG to give to the access transformer remapper